### PR TITLE
Update regtest block generation for v0.21.0

### DIFF
--- a/examples/transactions.rst
+++ b/examples/transactions.rst
@@ -93,7 +93,7 @@ Re-running the `“listunspent” RPC <../reference/rpc/listunspent.html>`__ wit
 
 ::
 
-   > bitcoin-cli -regtest generate 1
+   > bitcoin-cli -regtest -generate 1
 
    > unset NEW_ADDRESS
 
@@ -303,7 +303,7 @@ Send the signed transaction to the connected node using the `“sendrawtransacti
 
 ::
 
-   > bitcoin-cli -regtest generate 1
+   > bitcoin-cli -regtest -generate 1
 
    > unset UTXO_TXID UTXO_VOUT NEW_ADDRESS RAW_TX SIGNED_RAW_TX
 


### PR DESCRIPTION
`generate` is not supported anymore but must be `-generate`, see https://github.com/bitcoin/bitcoin/commit/92d94ffb8d07cc0d2665c901de5903a3a90d5fd0