### PR TITLE
Change terminology in getbestblockhash

### DIFF
--- a/reference/rpc/getbestblockhash.rst
+++ b/reference/rpc/getbestblockhash.rst
@@ -6,7 +6,7 @@ getbestblockhash
 
 ``getbestblockhash``
 
-Returns the hash of the best (tip) block in the longest blockchain.
+Returns the hash of the best (tip) block in the most-work fully-validated chain.
 
 Result
 ~~~~~~


### PR DESCRIPTION
RPC code:

````cpp
static RPCHelpMan getbestblockhash()
{
    return RPCHelpMan{"getbestblockhash",
                "\nReturns the hash of the best (tip) block in the most-work fully-validated chain.\n",
                {},
                RPCResult{
                    RPCResult::Type::STR_HEX, "", "the block hash, hex-encoded"},
                RPCExamples{
                    HelpExampleCli("getbestblockhash", "")
            + HelpExampleRpc("getbestblockhash", "")
                },
        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
{
    LOCK(cs_main);
    return ::ChainActive().Tip()->GetBlockHash().GetHex();
},
    };
}
