### PR TITLE
Add command to create wallet before generating blocks

### DIFF
--- a/examples/testing.rst
+++ b/examples/testing.rst
@@ -34,7 +34,11 @@ Start ``bitcoind`` in regtest mode to create a private block chain.
    ## Bitcoin Core 17.1 and earlier
    bitcoin-cli -regtest generate 101
 
-   ## Bitcoin Core 18.0 and later
+   ## Bitcoin Core 18.0 to 21.0
+   bitcoin-cli -regtest generatetoaddress 101 $(bitcoin-cli -regtest getnewaddress)
+   
+   ## Bitcoin Core 21.0 and later
+   bitcoin-cli -regtest createwallet "regtestwallet"
    bitcoin-cli -regtest generatetoaddress 101 $(bitcoin-cli -regtest getnewaddress)
 
 Generate 101 blocks using a special `RPC <../reference/rpc/index.html>`__ which is only available in regtest mode. This takes less than a second on a generic PC. Because this is a new block chain using Bitcoin’s default rules, the first blocks pay a block reward of 50 bitcoins. Unlike mainnet, in regtest mode only the first 150 blocks pay a reward of 50 bitcoins. However, a block must have 100 confirmations before that reward can be spent, so we generate 101 blocks to get access to the coinbase transaction from block #1.


### PR DESCRIPTION
Bitcoin 21.0+ no longer creates a default wallet, you must manually specify one with the `createwallet` command. `generatetoaddress` will fail if a wallet does not exist.