### PR TITLE
getrawtransaction verbose returns one address, not an array.

### DIFF
--- a/reference/rpc/getrawtransaction.rst
+++ b/reference/rpc/getrawtransaction.rst
@@ -92,12 +92,8 @@ Result (if verbose is set to true)
         "scriptPubKey" : {             (json object)
           "asm" : "str",               (string) the asm
           "hex" : "str",               (string) the hex
-          "reqSigs" : n,               (numeric) The required sigs
           "type" : "str",              (string) The type, eg 'pubkeyhash'
-          "addresses" : [              (json array)
-            "str",                     (string) bitcoin address
-            ...
-          ]
+          "address" : "str"            (string) bitcoin address
         }
       },
       ...


### PR DESCRIPTION
`reqSigs` and `addresses` fields were removed.
`address` was added.
See: https://github.com/bitcoin/bitcoin/commit/085b3a729952896ccd0e40c17df569f4421f5493