### PR TITLE
Fix power notation

### DIFF
--- a/devguide/block_chain.rst
+++ b/devguide/block_chain.rst
@@ -41,7 +41,7 @@ Chaining blocks together makes it impossible to modify transactions included in 
 
 The :term:`proof of work <Proof of work>` used in Bitcoin takes advantage of the apparently random nature of cryptographic hashes. A good cryptographic hash algorithm converts arbitrary data into a seemingly random number. If the data is modified in any way and the hash re-run, a new seemingly random number is produced, so there is no way to modify the data to make the hash number predictable.
 
-To prove you did some extra work to create a block, you must create a hash of the block header which does not exceed a certain value. For example, if the maximum possible hash value is 2256 − 1, you can prove that you tried up to two combinations by producing a hash value less than 2255.
+To prove you did some extra work to create a block, you must create a hash of the block header which does not exceed a certain value. For example, if the maximum possible hash value is 2²⁵⁶ − 1, you can prove that you tried up to two combinations by producing a hash value less than 2²⁵⁵.
 
 In the example given above, you will produce a successful hash on average every other try. You can even estimate the probability that a given hash attempt will generate a number below the :term:`target <nBits>` threshold. Bitcoin assumes a linear probability that the lower it makes the target threshold, the more hash attempts (on average) will need to be tried.
 

--- a/devguide/wallets.rst
+++ b/devguide/wallets.rst
@@ -127,7 +127,7 @@ Private Key Formats
 
 Private keys are what are used to unlock satoshis from a particular address. In Bitcoin, a private key in standard format is simply a 256-bit number, between the values:
 
-0x01 and 0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE BAAE DCE6 AF48 A03B BFD2 5E8C D036 4140, representing nearly the entire range of 2256-1 values. The range is governed by the `secp256k1 <http://www.secg.org/sec2-v2.pdf>`__ `ECDSA <https://en.wikipedia.org/wiki/Elliptic_Curve_DSA>`__ encryption standard used by Bitcoin.
+0x01 and 0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE BAAE DCE6 AF48 A03B BFD2 5E8C D036 4140, representing nearly the entire range of 2²⁵⁶-1 values. The range is governed by the `secp256k1 <http://www.secg.org/sec2-v2.pdf>`__ `ECDSA <https://en.wikipedia.org/wiki/Elliptic_Curve_DSA>`__ encryption standard used by Bitcoin.
 
 Wallet Import Format (WIF)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The numbers `2256` and `2255` in the text must be mis-formatted powers of 2, i.e. 2<sup>256</sup> and 2<sup>255</sup>, which is also the correct numbers in the given context.

I used unicode superscript numbers. Please let me know if there is a formatting option instead (e.g. something like `<sup>`).