### PR TITLE
[RPC helper] create directory if not exist

### DIFF
--- a/helpers/rpc/renderer_markdown.py
+++ b/helpers/rpc/renderer_markdown.py
@@ -312,6 +312,8 @@ class RendererMarkdown:
 
     def render_cmd_page(self, command, help_data):
         command_file = command + ".md"
+        if not os.path.exists(self.output_dir / "rpcs"):
+            os.mkdir(self.output_dir / "rpcs")
         with open(self.output_dir / "rpcs" / command_file, "w") as file:
             file.write(self.process_command_help(help_data))
 
@@ -358,6 +360,8 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.""")
             page, "0.11.0", "July 2015", new=True, updated=False)
 
     def render_overview_page(self, all_commands, render_version_info=True):
+        if not os.path.exists(self.output_dir):
+            os.mkdir(self.output_dir)
         with open(self.output_dir / "quick-reference.md", "w") as file:
             page = Page()
 


### PR DESCRIPTION
If we try to generate RPC reference in a non-existing directory, the script fail:
```shell
~/cp/developer.bitcoin.org/h/rpc master ?1 ❯ BITCOIN_CLI_PATH=bitcoin-cli python3 rpc_docs_helper generate --output-dir="/home/pyth/Desktop/rpc"
Command abandontransaction
Traceback (most recent call last):
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/rpc_docs_helper", line 91, in <module>
    main()
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/rpc_docs_helper", line 66, in main
    controller.generate(CliBitcoin(), renderer, arguments["COMMAND"])
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/cli_controller.py", line 19, in generate
    generator.generate_overview()
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/generator.py", line 27, in generate_overview
    self.generate_command(command)
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/generator.py", line 16, in generate_command
    self.renderer.render_cmd_page(command, help_data)
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/renderer_markdown.py", line 315, in render_cmd_page
    with open(self.output_dir / "rpcs" / command_file, "w") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/pyth/Desktop/rpc/rpcs/abandontransaction.md'
~/cp/developer.bitcoin.org/h/rpc master ?1 ❯ BITCOIN_CLI_PATH=bitcoin-cli python3 rpc_docs_helper generate --output-dir="/home/pyth/Desktop/rpc"
Traceback (most recent call last):
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/rpc_docs_helper", line 91, in <module>
    main()
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/rpc_docs_helper", line 66, in main
    controller.generate(CliBitcoin(), renderer, arguments["COMMAND"])
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/cli_controller.py", line 19, in generate
    generator.generate_overview()
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/generator.py", line 22, in generate_overview
    self.renderer.render_overview_page(command_list.grouped(),
  File "/home/pyth/cpp/developer.bitcoin.org/helpers/rpc/renderer_markdown.py", line 361, in render_overview_page
    with open(self.output_dir / "quick-reference.md", "w") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/pyth/Desktop/rpc/quick-reference.md'

```

This PR add a check + create directories if they not exist.